### PR TITLE
Delete arista class

### DIFF
--- a/practicaSysInt.py
+++ b/practicaSysInt.py
@@ -1,11 +1,5 @@
 import networkx as nx 
 
-class arista():
-	nodo_inicial=None
-	nodo_final=None
-	nombre=None
-	longitud=None
-
 class grafo():
 	graph=nx.Graph()
 	nodes=None
@@ -21,16 +15,15 @@ class grafo():
 			return posicion
 		else:
 			return "Error, el nodo no existe"
-	def adyacentesNodo(self,osmid_node):
+	def adyacentesNodo(self,nodo_inicial):
 		listaAristas=[]
-		if(self.perteneceNodo(osmid_node)):
-			for edge in self.graph.edges._adjdict[osmid_node]:
-				a=arista()
-				arista.nodo_inicial=osmid_node
-				arista.nodo_final=edge
-				arista.nombre=self.graph.edges._adjdict[osmid_node][edge][0]['name']
-				arista.longitud=self.graph.edges._adjdict[osmid_node][edge][0]['length']
-				listaAristas.append(a)
+		if(self.perteneceNodo(nodo_inicial)):
+			for nodo_final in self.graph.edges._adjdict[nodo_inicial]:
+				arista=[nodo_inicial,
+				nodo_final,
+				self.graph.edges._adjdict[nodo_inicial][nodo_final][0]['name'],
+				self.graph.edges._adjdict[nodo_inicial][nodo_final][0]['length']]
+				listaAristas.append(arista)
 		else:
 			return "Error, el nodo no existe"
 		return listaAristas
@@ -42,6 +35,8 @@ g=grafo(file)
 print(g.perteneceNodo(osmid))
 print(g.posicionNodo(osmid))
 print(g.adyacentesNodo(osmid))
+
+
 
 
 


### PR DESCRIPTION
He borrado la clase arista para que sólo entreguemos la clase grafo como corresponde con la práctica, para ello, en el método adyacentesNodo he construido un array para almacenar la información de una arista, queda un poquito más feo pero es como indica incluso en el ejemplo de la práctica, echadle un ojo